### PR TITLE
Naprawa błędu przy tworzeniu UsersController

### DIFF
--- a/KasaWGrupie.Infrastructure/AuthService/IAuthService.cs
+++ b/KasaWGrupie.Infrastructure/AuthService/IAuthService.cs
@@ -1,6 +1,9 @@
+using Microsoft.AspNetCore.Http;
+
 namespace KasaWGrupie.Infrastructure.AuthService;
 
 public interface IAuthService
 {
     Task<AuthenticationResult> AuthenticateAsync(string idToken, CancellationToken cancellationToken);
+    Task<string> GetEmailFromAuthTokenAsync(HttpContext context, CancellationToken cancellationToken);
 }

--- a/KasaWGrupieBackend/Controllers/UsersController.cs
+++ b/KasaWGrupieBackend/Controllers/UsersController.cs
@@ -13,7 +13,7 @@ namespace KasaWGrupie.API.Controllers;
 [Route("users")]
 [ApiController]
 public class UsersController(
-	AuthService authService,
+	IAuthService authService,
 	IMediator mediator
 ) : ControllerBase
 {


### PR DESCRIPTION
Korzystanie z któregokolwiek z endpointów users/ powodowuje bład:
InvalidOperationException: Unable to resolve service for type 'KasaWGrupie.Infrastructure.AuthService.AuthService' while attempting to activate 'KasaWGrupie.API.Controllers.UsersController'
Wystarczyło podmienić w konstruktorze AuthService na IAuthService